### PR TITLE
fix: correct Falied to Failed typo in job execution error response

### DIFF
--- a/src/service/sys/s_sys_job.rs
+++ b/src/service/sys/s_sys_job.rs
@@ -36,7 +36,7 @@ pub async fn hand_execute_job(VJson(arg): VJson<JobExecute>) -> impl IntoRespons
         execute_job(job).await;
         ApiResponse::ok("Success")
     } else {
-        ApiResponse::ok("Falied")
+        ApiResponse::ok("Failed")
     }
 }
 


### PR DESCRIPTION
Corrects the typo `Falied` -> `Failed` in the job execution error response.

**Before:**
\`\`\`rust
ApiResponse::ok("Falied")
\`\`\`

**After:**
\`\`\`rust
ApiResponse::ok("Failed")
\`\`\`
